### PR TITLE
add an org report for github activity

### DIFF
--- a/orgreports/2018-10-23_nteract.md
+++ b/orgreports/2018-10-23_nteract.md
@@ -1,0 +1,113 @@
+# Progress Report for [nteract](https://github.com/nteract) between 2018-10-16 and 2018-10-23
+
+### [vega-embed-v2](https://github.com/nteract/vega-embed-v2)
+-  [11 commits](https://github.com/nteract/vega-embed-v2/compare/master@%7B1539673200%7D...master@%7B1540278000%7D)
+
+#### Merged pull requests
+- [Strip comments to reduce bundle size to 700K](https://github.com/nteract/vega-embed-v2/pull/2) by [lgeiger](https://github.com/lgeiger)
+
+### [bookstore](https://github.com/nteract/bookstore)
+-  [14 commits](https://github.com/nteract/bookstore/compare/master@%7B1539673200%7D...master@%7B1540278000%7D)
+
+#### Merged pull requests
+- [add docs skeleton for RTD](https://github.com/nteract/bookstore/pull/3) by [willingc](https://github.com/willingc)
+- [setup the very basics of a jupyter extension](https://github.com/nteract/bookstore/pull/2) by [rgbkrk](https://github.com/rgbkrk)
+- [bootstrap the bookstore package](https://github.com/nteract/bookstore/pull/1) by [rgbkrk](https://github.com/rgbkrk)
+
+### [commuter-on-glitch](https://github.com/nteract/commuter-on-glitch)
+
+#### Merged pull requests
+- [[Followup] Point links to use the nteract organization's copy of the commuter demo](https://github.com/nteract/commuter-on-glitch/pull/1) by [hydrosquall](https://github.com/hydrosquall)
+
+### [docs](https://github.com/nteract/docs)
+-  [3 commits](https://github.com/nteract/docs/compare/master@%7B1539673200%7D...master@%7B1540278000%7D)
+
+#### Merged pull requests
+- [Add outline for play.nteract.io tutorial](https://github.com/nteract/docs/pull/38) by [captainsafia](https://github.com/captainsafia)
+
+### [papermill](https://github.com/nteract/papermill)
+-  [4 commits](https://github.com/nteract/papermill/compare/master@%7B1539673200%7D...master@%7B1540278000%7D)
+
+#### Merged pull requests
+- [stick an s in install](https://github.com/nteract/papermill/pull/237) by [rgbkrk](https://github.com/rgbkrk)
+- [Add note on using multiple AWS accounts](https://github.com/nteract/papermill/pull/234) by [aabdullah-bos](https://github.com/aabdullah-bos)
+
+### [nteract.io](https://github.com/nteract/nteract.io)
+-  [57 commits](https://github.com/nteract/nteract.io/compare/master@%7B1539673200%7D...master@%7B1540278000%7D)
+-  [7 closed issues](https://github.com/nteract/nteract.io/issues?utf8=%E2%9C%93&q=is%3Aissue%20closed%3A2018-10-16..2018-10-23)
+
+#### Merged pull requests
+- [Fix prettier config](https://github.com/nteract/nteract.io/pull/73) by [lgeiger](https://github.com/lgeiger)
+- [upgrade nteract members](https://github.com/nteract/nteract.io/pull/71) by [rgbkrk](https://github.com/rgbkrk)
+- [Remove legacy scss-based setup](https://github.com/nteract/nteract.io/pull/70) by [lgeiger](https://github.com/lgeiger)
+- [Show pointer cursor over logo since it links to home](https://github.com/nteract/nteract.io/pull/69) by [lgeiger](https://github.com/lgeiger)
+- [update to the current list of members](https://github.com/nteract/nteract.io/pull/68) by [rgbkrk](https://github.com/rgbkrk)
+- [Fixed a small typo](https://github.com/nteract/nteract.io/pull/67) by [grabartley](https://github.com/grabartley)
+- [added NumFocus link to the footer](https://github.com/nteract/nteract.io/pull/66) by [grabartley](https://github.com/grabartley)
+- [Cutoff image fix](https://github.com/nteract/nteract.io/pull/65) by [doraf](https://github.com/doraf)
+- [[ImgBot] Optimize images](https://github.com/nteract/nteract.io/pull/60) by [imgbot[bot]](https://github.com/apps/imgbot)
+- [Styled Components Refactor](https://github.com/nteract/nteract.io/pull/54) by [jdetle](https://github.com/jdetle)
+
+### [meeting-minutes](https://github.com/nteract/meeting-minutes)
+-  [5 commits](https://github.com/nteract/meeting-minutes/compare/master@%7B1539673200%7D...master@%7B1540278000%7D)
+-  [1 closed issue](https://github.com/nteract/meeting-minutes/issues?utf8=%E2%9C%93&q=is%3Aissue%20closed%3A2018-10-16..2018-10-23)
+
+### [nteract.github.io](https://github.com/nteract/nteract.github.io)
+-  [5 commits](https://github.com/nteract/nteract.github.io/compare/master@%7B1539673200%7D...master@%7B1540278000%7D)
+
+#### Merged pull requests
+- [Update index.html](https://github.com/nteract/nteract.github.io/pull/47) by [kelleyblackmore](https://github.com/kelleyblackmore)
+- [correct placement](https://github.com/nteract/nteract.github.io/pull/44) by [kelleyblackmore](https://github.com/kelleyblackmore)
+- [simple html redirect](https://github.com/nteract/nteract.github.io/pull/43) by [kelleyblackmore](https://github.com/kelleyblackmore)
+
+### [nteract](https://github.com/nteract/nteract)
+-  [110 commits](https://github.com/nteract/nteract/compare/master@%7B1539673200%7D...master@%7B1540278000%7D)
+-  [8 closed issues](https://github.com/nteract/nteract/issues?utf8=%E2%9C%93&q=is%3Aissue%20closed%3A2018-10-16..2018-10-23)
+
+#### Merged pull requests
+- [set box-sizing: border-box across all our apps](https://github.com/nteract/nteract/pull/3495) by [rgbkrk](https://github.com/rgbkrk)
+- [dont globally apply non-scoped styles](https://github.com/nteract/nteract/pull/3493) by [rgbkrk](https://github.com/rgbkrk)
+- [Fix docs for media components and fix JSON output](https://github.com/nteract/nteract/pull/3492) by [lgeiger](https://github.com/lgeiger)
+- [Make the chart obey theming](https://github.com/nteract/nteract/pull/3490) by [emeeks](https://github.com/emeeks)
+- [Change data explorer styling for dark theme](https://github.com/nteract/nteract/pull/3488) by [aaronraff](https://github.com/aaronraff)
+- [Bump @nteract/vega-embed-v2](https://github.com/nteract/nteract/pull/3487) by [lgeiger](https://github.com/lgeiger)
+- [Prettify javascript](https://github.com/nteract/nteract/pull/3485) by [jdetle](https://github.com/jdetle)
+- [Update data explorer](https://github.com/nteract/nteract/pull/3484) by [emeeks](https://github.com/emeeks)
+- [Fix saveContentEpic](https://github.com/nteract/nteract/pull/3479) by [lgeiger](https://github.com/lgeiger)
+- [Fix parallel coordinate plot and d3 import](https://github.com/nteract/nteract/pull/3478) by [lgeiger](https://github.com/lgeiger)
+- [unpack the nteract examples folder](https://github.com/nteract/nteract/pull/3477) by [rgbkrk](https://github.com/rgbkrk)
+- [Fix delete cell action](https://github.com/nteract/nteract/pull/3476) by [lgeiger](https://github.com/lgeiger)
+- [Some easy fixes to reduce the creation of new elements during render](https://github.com/nteract/nteract/pull/3475) by [lgeiger](https://github.com/lgeiger)
+- [Enforce order in our imports](https://github.com/nteract/nteract/pull/3472) by [lgeiger](https://github.com/lgeiger)
+- [ Fix inconsistent names for functions and actions/types - 2](https://github.com/nteract/nteract/pull/3470) by [rsnk96](https://github.com/rsnk96)
+- [Just the css for blueprint](https://github.com/nteract/nteract/pull/3469) by [rgbkrk](https://github.com/rgbkrk)
+- [Remove canvas dependency from vega](https://github.com/nteract/nteract/pull/3468) by [lgeiger](https://github.com/lgeiger)
+- [Update dependency electron to v3.0.5](https://github.com/nteract/nteract/pull/3464) by [renovate[bot]](https://github.com/apps/renovate)
+- [Add a Azure Pipelines status badge to the Readme](https://github.com/nteract/nteract/pull/3460) by [vijayma](https://github.com/vijayma)
+- [Fix import](https://github.com/nteract/nteract/pull/3459) by [rgbkrk](https://github.com/rgbkrk)
+- [Report kernel "launching" properly - Take two.](https://github.com/nteract/nteract/pull/3456) by [jameskoch](https://github.com/jameskoch)
+- [Debounce code completion requests.](https://github.com/nteract/nteract/pull/3455) by [jameskoch](https://github.com/jameskoch)
+- [Update node:8 Docker digest to 6b2c3d7](https://github.com/nteract/nteract/pull/3454) by [renovate[bot]](https://github.com/apps/renovate)
+- [Plain and Markdown media components](https://github.com/nteract/nteract/pull/3453) by [BenRussert](https://github.com/BenRussert)
+- [[Commuter-3233] Point to nteract instead of personal copy of commuter demo](https://github.com/nteract/nteract/pull/3452) by [hydrosquall](https://github.com/hydrosquall)
+- [Craft issue templates](https://github.com/nteract/nteract/pull/3450) by [rgbkrk](https://github.com/rgbkrk)
+- [Integration points for jupyter-widgets in nteract.](https://github.com/nteract/nteract/pull/3445) by [jdfreder](https://github.com/jdfreder)
+- [Fix inconsistent names for functions and actions/types](https://github.com/nteract/nteract/pull/3442) by [rsnk96](https://github.com/rsnk96)
+- [Update dependency elasticsearch to v15](https://github.com/nteract/nteract/pull/3401) by [renovate[bot]](https://github.com/apps/renovate)
+- [Upgrade rxjs and redux-observable](https://github.com/nteract/nteract/pull/3399) by [lgeiger](https://github.com/lgeiger)
+- [Update dependency reselect to v4](https://github.com/nteract/nteract/pull/3385) by [renovate[bot]](https://github.com/apps/renovate)
+
+### [hydrogen](https://github.com/nteract/hydrogen)
+-  [1 commit](https://github.com/nteract/hydrogen/compare/master@%7B1539673200%7D...master@%7B1540278000%7D)
+-  [3 closed issues](https://github.com/nteract/hydrogen/issues?utf8=%E2%9C%93&q=is%3Aissue%20closed%3A2018-10-16..2018-10-23)
+
+#### Merged pull requests
+- [Hide autocomplete suggestions in run and runCell](https://github.com/nteract/hydrogen/pull/1454) by [kylebarron](https://github.com/kylebarron)
+
+### [scrapbook](https://github.com/nteract/scrapbook)
+-  [2 commits](https://github.com/nteract/scrapbook/compare/master@%7B1539673200%7D...master@%7B1540278000%7D)
+
+## Totals
+- Commits: 212
+- Pull requests: 60
+- Issues: 29


### PR DESCRIPTION
This adds an organization level report for GitHub activity for the past week using [org-pulse](https://github.com/willingc/org-pulse/tree/jhub)
